### PR TITLE
Pass content_type parameter to insert_object().

### DIFF
--- a/lib/acmesmith/storages/google_cloud_storage.rb
+++ b/lib/acmesmith/storages/google_cloud_storage.rb
@@ -65,7 +65,12 @@ module Acmesmith
           name: account_key_key,
           content_type: 'application/x-pem-file'
         )
-        @api.insert_object(bucket, obj, upload_source: StringIO.new(key.export(passphrase)))
+        @api.insert_object(
+          bucket,
+          obj,
+          upload_source: StringIO.new(key.export(passphrase)),
+          content_type: 'application/x-pem-file',
+        )
       end
 
       def put_certificate(cert, passphrase = nil, update_current: true)
@@ -76,7 +81,12 @@ module Acmesmith
             name: key,
             content_type: 'application/x-pem-file',
           )
-          @api.insert_object(bucket, obj, upload_source: StringIO.new(body))
+          @api.insert_object(
+            bucket,
+            obj,
+            upload_source: StringIO.new(body),
+            content_type: 'application/x-pem-file',
+          )
         end
 
         put.call certificate_key(cert.common_name, cert.version), "#{h[:certificate].rstrip}\n"
@@ -89,6 +99,7 @@ module Acmesmith
             bucket,
             Google::Apis::StorageV1::Object.new(name: certificate_current_key(cert.common_name), content_type: 'text/plain'),
             upload_source: StringIO.new(cert.version),
+            content_type: 'text/plain',
           )
         end
       end


### PR DESCRIPTION
Hi,

Thank you for creating this library! Now I managed to store my certificates on GCS, but needed to make a small change to make 'acmesmith request COMMON_NAME' work.

Without the attached change, I saw the following error:
> Google::Apis::ClientError: invalid: Content-Type specified in the upload
> (application/octet-stream) does not match Content-Type specified in metadata
> (application/x-pem-file). If it was a simple upload (uploadType=media),
> the Content-Type was specified as a bare header.
> If it was a multipart upload(uploadType=multipart), then the Content-Type
> was specified in the second part of the multipart. If it was
> a resumable upload (uploadType=resumable), then the Content-Type was specified
> with the X-Upload-Content-Type header with the start of the resumable session.
> For more information,
> see https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload.

Please take a look at the patch. Thanks!